### PR TITLE
fix: build package on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format": "sort-package-json && prettier --write '**/*.{ts,js,json,yml,md}' && eslint --fix .",
     "lint": "eslint . && ec .",
     "lint:fix": "eslint . --fix && ec .",
-    "prepare": "husky install || true",
+    "prepare": "npm run build && husky install || true",
     "release:major": "npm version major --no-commit-hooks && git push --follow-tags",
     "release:minor": "npm version minor --no-commit-hooks && git push --follow-tags",
     "release:patch": "npm version patch --no-commit-hooks && git push --follow-tags",


### PR DESCRIPTION
## Summary
Adds TypeScript compilation to the prepare script so the package builds when installed as a git dependency.

## Problem
When installing this package as a git dependency, the TypeScript source files are not compiled, causing consuming packages to fail with:
```
Cannot find module 'sentry-traced' or its corresponding type declarations
```

The package publishes only the `/lib` directory (compiled output), but the prepare script wasn't building it.

## Solution
Updated the prepare script to build the package before running husky:
```json
"prepare": "npm run build && husky install || true"
```

Now when the package is installed as a git dependency:
1. TypeScript compiles src → lib
2. Husky installation runs (or gracefully fails if not available)
3. Consuming packages get the compiled JavaScript and type definitions

## Related
- Required for https://github.com/fullstackhouse/tournee-api to build with this package as a git dependency